### PR TITLE
Fix DNS delegation error

### DIFF
--- a/cloud-shell-infra-init.sh
+++ b/cloud-shell-infra-init.sh
@@ -18,3 +18,14 @@ gcloud anthos config controller create php-01hhmj81fhp-dns \
     --full-management \
     --network=projects/php-01hhmj81fhp/global/networks/php-01hhmj81fhp-vpc-01 \
     --subnet=projects/php-01hhmj81fhp/regions/northamerica-northeast1/subnetworks/php-01hhmj81fhp-vpc-01-sub-01 
+
+# Configure config controller instance - https://cloud.google.com/anthos-config-management/docs/how-to/config-controller-setup#use-config-controller
+gcloud container clusters get-credentials krmapihost-php-01hhmj81fhp-dns --region northamerica-northeast1 --project php-01hhmj81fhp
+
+export SA_EMAIL="$(kubectl get ConfigConnectorContext -n config-control \
+    -o jsonpath='{.items[0].spec.googleServiceAccount}' 2> /dev/null)"
+
+gcloud projects add-iam-policy-binding php-01hhmj81fhp \
+    --member "serviceAccount:${SA_EMAIL}" \
+    --role "roles/dns.admin" \
+    --project php-01hhmj81fhp

--- a/dns-records/hopic-data-donnes-phac-aspc-gc-ca.yaml
+++ b/dns-records/hopic-data-donnes-phac-aspc-gc-ca.yaml
@@ -2,7 +2,7 @@ apiVersion: dns.cnrm.cloud.google.com/v1beta1
 kind: DNSRecordSet
 metadata:
   name: hopic-data-donnes-phac-aspc-gc-ca
-  namespace: phac-dns
+  namespace: config-control
   annotations:
     projectName: "hopic"
     sourceCodeRepository: "https://github.com/PHACDataHub/cpho-phase2/"


### PR DESCRIPTION
- Add missing permissions for config controller service account.
  I've given it a `roles/dns.admin` permission since it's only expected to interact with DNS resources on the cloud. 
- Update namespace for hopic DNS record set to `config-control`, since a `ConfigConnectorContext` resource exists in that namespace.

Closes #2 