### PR TITLE
Update DNS Configuration for DHIS2 Project

### DIFF
--- a/dns-records/dhis2-beta-phac-aspc-gc-ca.yaml
+++ b/dns-records/dhis2-beta-phac-aspc-gc-ca.yaml
@@ -11,7 +11,7 @@ spec:
   type: "NS"
   ttl: 300
   managedZoneRef:
-    external: dhis2-beta-phac-aspc-gc-ca
+    external: beta-phac-aspc-gc-ca
   rrdatas:
     - ns-cloud-e1.googledomains.com.
     - ns-cloud-e2.googledomains.com.

--- a/dns-records/dhis2-beta-phac-aspc-gc-ca.yaml
+++ b/dns-records/dhis2-beta-phac-aspc-gc-ca.yaml
@@ -1,0 +1,19 @@
+apiVersion: dns.cnrm.cloud.google.com/v1beta1
+kind: DNSRecordSet
+metadata:
+  name: dhis2-beta-phac-aspc-gc-ca
+  namespace: config-control
+  annotations:
+    projectName: "dhis2"
+    sourceCodeRepository: "https://github.com/PHACDataHub/dhis-2/"
+spec:
+  name: "dhis2.beta.phac-aspc.gc.ca."
+  type: "NS"
+  ttl: 300
+  managedZoneRef:
+    external: dhis2-beta-phac-aspc-gc-ca
+  rrdatas:
+    - ns-cloud-e1.googledomains.com.
+    - ns-cloud-e2.googledomains.com.
+    - ns-cloud-e3.googledomains.com.
+    - ns-cloud-e4.googledomains.com.


### PR DESCRIPTION
Description:

This pull request includes the addition of a new DNSRecordSet for dhis2.beta.phac-aspc.gc.ca, specifying Google Domains as the authoritative name servers.

Changes:

Added DNSRecordSet for dhis2.beta.phac-aspc.gc.ca with NS records pointing to Google Domains name servers.
Set a TTL of 300 seconds for the new record set to optimize DNS resolution without compromising on caching efficiency.
Included metadata annotations for project reference and source code repository link for better traceability and documentation.