### PR TITLE
Add NS records for `infra-auth`

### DIFF
--- a/dns-records/infra-auth-alpha-phac-gc-ca.yaml
+++ b/dns-records/infra-auth-alpha-phac-gc-ca.yaml
@@ -1,0 +1,18 @@
+apiVersion: dns.cnrm.cloud.google.com/v1beta1
+kind: DNSRecordSet
+metadata:
+  name: infra-auth-alpha-phac-gc-ca
+  namespace: config-control
+  annotations:
+    projectName: "Infrastructure SSO"
+spec:
+  name: "infra-auth.alpha.phac.gc.ca."
+  type: "NS"
+  ttl: 300
+  managedZoneRef:
+    external: alpha-phac-gc-ca
+  rrdatas:
+    - ns-cloud-e1.googledomains.com.
+    - ns-cloud-e2.googledomains.com.
+    - ns-cloud-e3.googledomains.com.
+    - ns-cloud-e4.googledomains.com.


### PR DESCRIPTION
Add NS records for `infra-auth` subdomain to test out a central [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy) deployment for securing multiple K8s services. The zone for this subdomain is hosted under `phx-vedantthapa` GCP project.

I'll delete this resource and it's corresponding zone once the testing is completed.