### PR TITLE
Fix root-sync name

### DIFF
--- a/root-sync.yaml
+++ b/root-sync.yaml
@@ -17,7 +17,7 @@ spec:
 apiVersion: configsync.gke.io/v1beta1
 kind: RootSync
 metadata:
-  name: root-sync
+  name: root-sync-zones
   namespace: config-management-system
 spec:
   git:


### PR DESCRIPTION
Update root-sync name for zone to `root-sync-zones`