### PR TITLE
Revert "Add deletion policy"

### DIFF
--- a/zones/alpha-phac-aspc-gc-ca.yaml
+++ b/zones/alpha-phac-aspc-gc-ca.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     cnrm.cloud.google.com/force-destroy: "false"
     cnrm.cloud.google.com/project-id: php-01hhmj81fhp
-    cnrm.cloud.google.com/deletion-policy: abandon
   name: alpha-phac-aspc-gc-ca
 spec:
   dnsName: alpha.phac-aspc.gc.ca.

--- a/zones/alpha-phac-gc-ca.yaml
+++ b/zones/alpha-phac-gc-ca.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     cnrm.cloud.google.com/force-destroy: "false"
     cnrm.cloud.google.com/project-id: php-01hhmj81fhp
-    cnrm.cloud.google.com/deletion-policy: abandon
   name: alpha-phac-gc-ca
 spec:
   dnsName: alpha.phac.gc.ca.

--- a/zones/beta-phac-aspc-gc-ca.yaml
+++ b/zones/beta-phac-aspc-gc-ca.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     cnrm.cloud.google.com/force-destroy: "false"
     cnrm.cloud.google.com/project-id: php-01hhmj81fhp
-    cnrm.cloud.google.com/deletion-policy: abandon
   name: beta-phac-aspc-gc-ca
 spec:
   dnsName: beta.phac-aspc.gc.ca.

--- a/zones/beta-phac-gc-ca.yaml
+++ b/zones/beta-phac-gc-ca.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     cnrm.cloud.google.com/force-destroy: "false"
     cnrm.cloud.google.com/project-id: php-01hhmj81fhp
-    cnrm.cloud.google.com/deletion-policy: abandon
   name: beta-phac-gc-ca
 spec:
   dnsName: beta.phac.gc.ca.

--- a/zones/data-phac-gc-ca.yaml
+++ b/zones/data-phac-gc-ca.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     cnrm.cloud.google.com/force-destroy: "false"
     cnrm.cloud.google.com/project-id: php-01hhmj81fhp
-    cnrm.cloud.google.com/deletion-policy: abandon
   name: data-phac-gc-ca
 spec:
   dnsName: data.phac.gc.ca.


### PR DESCRIPTION
Reverts PHACDataHub/phac-dns#62

No longer need the deletion-policy annotation since the resources are now ready with an `UpToDate` status.