### PR TITLE
feat: add hopic-data-phac-gc-ca

### DIFF
--- a/dns-records/hopic-data-phac-gc-ca.yaml
+++ b/dns-records/hopic-data-phac-gc-ca.yaml
@@ -1,0 +1,20 @@
+apiVersion: dns.cnrm.cloud.google.com/v1beta1
+kind: DNSRecordSet
+metadata:
+  name: hopic-data-phac-gc-ca
+  namespace: config-control
+  annotations:
+    projectName: "hopic"
+    projectId: "pht-01hp04dtnkf"
+    sourceCodeRepository: "https://github.com/PHACDataHub/cpho-phase2/"
+spec:
+  name: "hopic-sdpac.data.phac.gc.ca."
+  type: "NS"
+  ttl: 300
+  managedZoneRef:
+    external: data-phac-gc-ca
+  rrdatas:
+    - ns-cloud-c1.googledomains.com.
+    - ns-cloud-c2.googledomains.com.
+    - ns-cloud-c3.googledomains.com.
+    - ns-cloud-c4.googledomains.com.


### PR DESCRIPTION
Add DNS delegation for hopic-sdpac.data.phac.gc.ca.

Since the `phac-aspc.gc.ca` subdomains fail to resolve correctly in the office environment, we'll be moving off to `data.phac.gc.ca` so that the users can access the endpoint. We will need the [hopic-sdpac.data-donnes.phac-aspc.gc.ca record set](https://github.com/PHACDataHub/phac-dns/blob/main/dns-records/hopic-data-donnes-phac-aspc-gc-ca.yaml) around for a couple of weeks though. I'll submit a PR to clean it up once I've received a confirmation from the application team.