### PR TITLE
Add grep to validate actions

### DIFF
--- a/.github/workflows/validate-namespace.yaml
+++ b/.github/workflows/validate-namespace.yaml
@@ -27,7 +27,7 @@ jobs:
         error_occurred=0
         
         # Find yml/yaml files that have been changed    
-        yaml_files=($(git diff --name-only HEAD^..HEAD))
+        yaml_files=($(git diff --name-only HEAD^..HEAD | grep -E '^dns-records/.*\.ya?ml$'))
 
         # Check if there are any YAML files to process
         if [ ${#yaml_files[@]} -eq 0 ]; then

--- a/.github/workflows/validate-zone.yaml
+++ b/.github/workflows/validate-zone.yaml
@@ -39,7 +39,7 @@ jobs:
         done <<< "$valid_zones_data"
 
         # Find changed YAML files
-        yaml_files=($(git diff --name-only HEAD^..HEAD))
+        yaml_files=($(git diff --name-only HEAD^..HEAD | grep -E '^dns-records/.*\.ya?ml$'))
 
         # Check if there are any YAML files to process
         if [ ${#yaml_files[@]} -eq 0 ]; then


### PR DESCRIPTION
Added a grep command so that only the files located in the dns-records repository are processed by the validate actions. Temporary fix until a better solution is found.