### PR TITLE
Signal Detection Platform DNS Request

### DIFF
--- a/dns-records/signals-signaux-alpha-phac-aspc-gc-ca.yaml
+++ b/dns-records/signals-signaux-alpha-phac-aspc-gc-ca.yaml
@@ -1,0 +1,20 @@
+apiVersion: dns.cnrm.cloud.google.com/v1beta1
+kind: DNSRecordSet
+metadata:
+  name: signals-signaux-alpha-phac-aspc-gc-ca
+  namespace: config-control
+  annotations:
+    projectName: "Signal Detection Platform"
+    projectId: "phx-01hnapr4ab4"
+    sourceCodeRepository: "https://github.com/PHACDataHub/foresight/"
+spec:
+  name: "signals-signaux.alpha.phac-aspc.gc.ca."
+  type: "NS"
+  ttl: 300
+  managedZoneRef:
+    external: alpha-phac-aspc-gc-ca
+  rrdatas:
+    - ns-cloud-e1.googledomains.com.
+    - ns-cloud-e2.googledomains.com.
+    - ns-cloud-e3.googledomains.com.
+    - ns-cloud-e4.googledomains.com.


### PR DESCRIPTION
### Overview
This pull request updates the DNS configuration for the Signal Detection Platform. The changes aim to modify the nameserver records for the domain `signals-signaux.alpha.phac-aspc.gc.ca` to ensure it is correctly configured to use Google's managed nameservers.

### Changes
- Added a new `DNSRecordSet` for `signals-signaux.alpha.phac-aspc.gc.ca` with updated nameserver details.
- Configured TTL to 300 seconds to allow for quicker propagation and updates.

### Additional Information
- **Project ID**: `phx-01hnapr4ab4`
- **Managed Zone**: `alpha-phac-aspc-gc-ca`
- **Source Code Repository**: [GitHub Repository](https://github.com/PHACDataHub/foresight)

Please review the changes and provide your feedback or approval at your earliest convenience. Thank you!
