### PR TITLE
fix: remove terminal references

### DIFF
--- a/infra-deployment-scripts/cloud-shell-infra-init.sh
+++ b/infra-deployment-scripts/cloud-shell-infra-init.sh
@@ -60,7 +60,7 @@ gcloud projects add-iam-policy-binding "${GOOGLE_CLOUD_PROJECT}" \
     --role "roles/compute.publicIpAdmin" \
     --project "${GOOGLE_CLOUD_PROJECT}"
 
-gcloud iam service-accounts add-iam-policy-binding \                                                                                                                                                                                                                  py base gcloud pht-scienceportal
+gcloud iam service-accounts add-iam-policy-binding \
   "sa-${GOOGLE_CLOUD_PROJECT}-phac-dns@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com" \
   --member="serviceAccount:${GOOGLE_CLOUD_PROJECT}.svc.id.goog[cnrm-system/cnrm-controller-manager-dns]" \
   --role="roles/iam.workloadIdentityUser" \


### PR DESCRIPTION
Clear out trailing whitespace and terminal references. 

I included the `py base gcloud pht-scienceportal` while copy-pasting the command from my terminal lol.