### PR TITLE
paradire-alpha-phac-gc-ca

### DIFF
--- a/dns-records/paradire-alpha-phac-gc-ca.yaml
+++ b/dns-records/paradire-alpha-phac-gc-ca.yaml
@@ -1,0 +1,22 @@
+apiVersion: dns.cnrm.cloud.google.com/v1beta1
+kind: DNSRecordSet
+metadata:
+  name: paradire-alpha-phac-gc-ca
+  namespace: dns
+  annotations:
+    sourceCodeRepository: "https://github.com/PHACDataHub/data-mesh-ref-impl/tree/main/paradire"
+  labels:
+    controlled-by: "phac-dns"
+    project-name: "phx-paradire"
+    project-id: "phx-01he5rx4wsv"
+spec:
+  name: paradire.alpha.phac.gc.ca.
+  type: "NS"
+  ttl: 300
+  managedZoneRef:
+    external: alpha-phac-gc-ca
+  rrdatas:
+    - ns-cloud-d1.googledomains.com.
+    - ns-cloud-d2.googledomains.com.
+    - ns-cloud-d3.googledomains.com.
+    - ns-cloud-d4.googledomains.com.


### PR DESCRIPTION
Adding the DNS Zone for Paradire (IRG) Project.