### PR TITLE
Update actions fetch-depth

### DIFF
--- a/.github/workflows/validate-domain.yaml
+++ b/.github/workflows/validate-domain.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
-          fetch-depth: 0
+          fetch-depth: 2
 
     - name: Validate Domains
       id: validate_domains

--- a/.github/workflows/validate-manadatory-fields.yaml
+++ b/.github/workflows/validate-manadatory-fields.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
-        fetch-depth: 0
+        fetch-depth: 2
 
     - name: Validate mandatory fields
       id: validate-mandatory-fields

--- a/.github/workflows/validate-namespace.yaml
+++ b/.github/workflows/validate-namespace.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
-        fetch-depth: 0
+        fetch-depth: 2
 
     - name: Install yq
       uses: mikefarah/yq@v4

--- a/.github/workflows/validate-zone.yaml
+++ b/.github/workflows/validate-zone.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
-        fetch-depth: 0
+        fetch-depth: 2
 
     - name: Validate zone
       id: validate-zone


### PR DESCRIPTION
Changed fetch-depth in GitHub Actions from 0 to 2 to limit the commit history fetched, reducing unnecessary data retrieval.