### PR TITLE
release: iidi

### DIFF
--- a/dns-records/iidi-alpha-phac-gc-ca.yaml
+++ b/dns-records/iidi-alpha-phac-gc-ca.yaml
@@ -1,0 +1,22 @@
+apiVersion: dns.cnrm.cloud.google.com/v1beta1
+kind: DNSRecordSet
+metadata:
+  name: iidi-alpha-phac-gc-ca
+  namespace: dns
+  annotations:
+    sourceCodeRepository: "https://github.com/PHACDataHub/data-mesh-ref-impl/tree/main/paradire"
+  labels:
+    controlled-by: "phac-dns"
+    project-name: "phx-paradire"
+    project-id: "phx-01he5rx4wsv"
+spec:
+  name: iidi.alpha.phac.gc.ca.
+  type: "NS"
+  ttl: 300
+  managedZoneRef:
+    external: alpha-phac-gc-ca
+  rrdatas:
+    - ns-cloud-d1.googledomains.com.
+    - ns-cloud-d2.googledomains.com.
+    - ns-cloud-d3.googledomains.com.
+    - ns-cloud-d4.googledomains.com.


### PR DESCRIPTION

**Purpose**:  
This merge adds a new **DNSRecordSet** for the `iidi.alpha.phac.gc.ca` subdomain under the `alpha.phac.gc.ca` managed zone. The DNS delegation points to Google's authoritative name servers.

**Details**:
- **Subdomain**: `iidi.alpha.phac.gc.ca`
- **Managed Zone Reference**: `alpha-phac-gc-ca`
- **Name Servers**:
  - `ns-cloud-d1.googledomains.com`
  - `ns-cloud-d2.googledomains.com`
  - `ns-cloud-d3.googledomains.com`
  - `ns-cloud-d4.googledomains.com`
- **TTL**: 300 seconds
- **Source Code Repository**: [[data-mesh-ref-impl/tree/main/paradire](https://github.com/PHACDataHub/data-mesh-ref-impl/tree/main/paradire)](https://github.com/PHACDataHub/data-mesh-ref-impl/tree/main/paradire)